### PR TITLE
Container-updates group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,9 @@ version: 2
 multi-ecosystem-groups:
   app-dependencies:
     schedule:
-      interval: "cron"
-      cronjob: "0 6 1-7 * 1" # Every first Monday of the month at 6:00am
+      interval: "monthly"
+      time: "06:00"
+      day: "monday"
       timezone: "America/Detroit"
     commit-message:
       prefix: "Monthly dependency updates: "

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ multi-ecosystem-groups:
     commit-message:
       prefix: "Monthly dependency updates: "
 
+  container-updates:
+    schedule:
+      interval: "cron"
+      cronjob: "0 6 3 4 *" #April 3 at 6AM
+      timezone: "America/Detroit"
+    commit-message:
+      prefix: "Annual container update: "
+
 updates:
   # For npm/JavaScript dependencies
   - package-ecosystem: "npm"
@@ -31,11 +39,11 @@ updates:
   # For Docker
   - package-ecosystem: "docker"
     directory: "/"
-    multi-ecosystem-group: "app-dependencies"
+    multi-ecosystem-group: "container-updates"
     patterns: ["*"]
 
   # For Docker Compose
   - package-ecosystem: "docker-compose"
     directory: "/"
-    multi-ecosystem-group: "app-dependencies"
+    multi-ecosystem-group: "container-updates"
     patterns: ["*"]

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,32 +1,25 @@
 name: Dependabot pull requests
 
-on:
-  workflow_run:
-    workflows: ["Run Tests"]
-    types:
-      - completed
+on: pull_request
+
 jobs:
   dependabot:
     name: Auto-merge Dependabot PRs
     runs-on: ubuntu-latest
-    # Only trigger if tests have passed on a Dependabot-created PR
-    if: |
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.pull_requests != '' &&
-      startsWith(github.event.workflow_run.head_branch, 'dependabot/') &&
-      github.event.workflow_run.pull_requests[0].user.login == 'dependabot[bot]'
+    if:  ${{github.event.pull_request.user.login == 'dependabot[bot]'}}
     permissions:
       pull-requests: write
       contents: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PR_URL: ${{ github.event.workflow_run.pull_requests[0].html_url }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
     steps:
-      - name: Dependabot metadata
-        id: dependabot-metadata
+      - name: Fetch Dependabot Metadata
         uses: dependabot/fetch-metadata@v2
+        id: dependabot-metadata
       - name: Approve and Merge the PR
-        if: ${{ steps.dependabot-metadata.outputs.dependency-group == 'app-dependencies' }}
+        # Don't do this for the container-updates group
+        if: ${{ steps.dependabot-metadata.outputs.dependency-group != 'container-updates' }}
         run: |
           gh pr review --approve "$PR_URL"
           gh pr merge --squash --auto "$PR_URL"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -5,7 +5,6 @@ on:
     workflows: ["Run Tests"]
     types:
       - completed
-
 jobs:
   dependabot:
     name: Auto-merge Dependabot PRs
@@ -23,11 +22,11 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PR_URL: ${{ github.event.workflow_run.pull_requests[0].html_url }}
     steps:
-      - name: Fetch Dependabot Metadata
+      - name: Dependabot metadata
+        id: dependabot-metadata
         uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Approve the PR
-        run: gh pr review --approve "$PR_URL"
-      - name: Merge the PR
-        run: gh pr merge --squash --auto "$PR_URL"
+      - name: Approve and Merge the PR
+        if: ${{ steps.dependabot-metadata.outputs.dependency-group == 'app-dependencies' }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --squash --auto "$PR_URL"


### PR DESCRIPTION
Adds second dependency group for Dockerfile and docker-compose because we only want to update those yearly. We also don't want those to auto-merge because tests will not automatically catch changes due to the image change because the tests GHA won't get an automated ruby version update.

Also changes from cron to monthly for interval for app-dependencies group. 

Also goes back to checking for PR updates. Status checks are required in the branch rules.